### PR TITLE
fix paste transform

### DIFF
--- a/vrdoodler.html
+++ b/vrdoodler.html
@@ -1357,7 +1357,7 @@
 							
                    		    lineToCopyIndex = drawnline.findIndex(findUUID);
                    		    if (drawnline[lineToCopyIndex].parent.name == "linegroup")
-                   		    	copiedObj = drawnline[lineToCopyIndex].parent.clone();
+                   		    	copiedObj = drawnline[lineToCopyIndex].parent;
                    		    	//else what.. what else would be copied if every line now is in a group
                    		   // elscopiedObj = drawnline[lineToCopyIndex].clone();
                    		    //copiedLine.position.set( 0, 0, 0 );
@@ -1372,52 +1372,31 @@
                    	if (evt.ctrlKey || evt.metaKey){
                    		if (currentIntersectedPoint && copiedObj){
                    		
-                   		 	console.log(" intersected point" + JSON.stringify(currentIntersected.matrixWorld));
-							
-							//if userSettings.userLevel == 'advanced'), use plane?
-							var matrixMod =plane.clone();
-		
+							//if userSettings.userLevel == 'advanced'), use plane?		
 							var copiedObj2;
 							if (copiedObj.name == "linegroup"){
 								
 									copiedObj2 = new THREE.Object3D();
 									for (l = 0;l<copiedObj.children.length;l++){
 									
-										var newLine = copiedObj.children[l].clone();
-										newLine.geometry= newLine.geometry.clone();
-										var box = new THREE.Box3().setFromObject(copiedObj);
-										newLine.geometry.computeBoundingBox();
-										var offset = box.min.clone();
-										
-										var attribute = newLine.geometry.attributes.position;
-										for (var e = 0;e<attribute.count;e++){
-											var vec = new THREE.Vector3();
-											vec.fromAttribute( attribute, e ); // extract the x,y,z coordinates						
-										
-											//how do I 'zero-out' the vertex?  normalize it?
-											var source = vec.clone();
-										
-											var originOffset = newLine.position.clone();
-											var origin = vec.clone();
-											//var distance = originOffset.distanceTo(origin);
-									
-											var newPos = currentIntersectedPoint.clone();
-											var zeroMatrix = new THREE.Object3D();
-											zeroMatrix.position.set(0,0,0);
-											origin.sub(offset);  
-										
-											origin.applyMatrix4( matrixMod.matrixWorld ); // apply the mesh's matrix transform
-											
-									
-											attribute.setXYZ (e, origin.x, origin.y, origin.z);	
-										}
-										//newLine.geometry.attributes.position = attribute;
-										newLine.geometry.attributes.position.needsUpdate = true;
-										drawnline.push(newLine);
-										copiedObj2.name="linegroup";
-										copiedObj2.add(newLine);	
-									
-									
+                                        var originalTransform = copiedObj.children[l].planeTransform;
+                                        if (originalTransform) {
+    										var newLine = copiedObj.children[l].clone();
+    										newLine.geometry= newLine.geometry.clone();
+    										
+    										var attribute = newLine.geometry.attributes.position;
+                                            newLine.geometry.applyMatrix(
+                                                plane.matrixWorld.clone().multiply(
+                                                    new THREE.Matrix4().getInverse(originalTransform)
+                                                )
+                                            )
+                                            
+    										newLine.geometry.attributes.position = attribute;
+    										newLine.geometry.attributes.position.needsUpdate = true;
+    										drawnline.push(newLine);
+    										copiedObj2.name="linegroup";
+    										copiedObj2.add(newLine);	
+					                    }									
 									}
 									objContainer.add(copiedObj2);
 							
@@ -1660,6 +1639,7 @@
 			
 			linematerial = new THREE.LineBasicMaterial( { color: 0xffffff, linewidth: getCurrentLineWidth() } );
 			newOrImportedLine = new THREE.Line( geometry,  linematerial );
+            newOrImportedLine.planeTransform = plane.matrixWorld;
 			drawnline.push(newOrImportedLine); //to store line	
 		mostRecentDrawnLine().position = mv; //for later...
 		


### PR DESCRIPTION
This change makes pasting work, but only for objects that have not been downloaded and then imported.

The problem with the existing code was that it was using the lower left corner of the object's bounding box as the origin. This meant that pasted objects would generally be offset up and to the right (depending on where they were drawn on the original plane). This strategy also lacked any compensation for rotations of the original drawing, so pasting and object that was drawn after the camera was rotated would result in a drawing at an angle to the destination plane.

Unfortunately, by the time we copy a drawing, information about the plane it was drawn on is lost. This PR addresses that by storing the transform of the drawing plane when the line is initialized. We can invert this matrix to transform the drawing to a plane unrotated at the origin and then apply the new plane's world matrix to move the lines to the correct place. This works well.

The downside is the stored plane matrix is lost when we save it to the obj file. The obj file format doesn't appear to be capable of storing arbitrary information like this. I noticed that the line widths also change after reloading, so it might be worth moving to a more flexible format. Another option would be to compute the matrix from the points. They all line in a plane, so it should be reasonably easy to solve for the transform, but it's a bit of a project, so I thought this would do for now.
